### PR TITLE
Revert "Enable SRV/.well-known lookups"

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func exchangeOIDCToken(
 		return nil, errors.New("No results returned from server name resolution!")
 	}
 
-	client := fclient.NewClient(fclient.WithWellKnownSRVLookups(true))
+	client := fclient.NewClient()
 	// validate the openid token by getting the user's ID
 	userinfo, err := client.LookupUserInfo(
 		ctx, resolveResults[0].Host, token.AccessToken,


### PR DESCRIPTION
Reverts vector-im/lk-jwt-service#8

Turns out this doesn't work as it fails the check at the end of the function:

```
2023/07/11 17:12:38 Failed to look up user info: userID doesn't match server name '@lime-spicy-ox:call.ems.host' != 'call.ems.host:443'
```