### PR TITLE
Add a simple health check endpoint to satisfy k8s needs

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,6 +72,17 @@ func exchangeOIDCToken(
 	return &userinfo, nil
 }
 
+func (h *Handler) healthcheck(w http.ResponseWriter, r *http.Request) {
+	log.Printf("Health check from %s", r.RemoteAddr)
+
+	if r.Method == "GET" {
+		w.WriteHeader(http.StatusOK)
+		return
+	} else {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
 func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Request from %s", r.RemoteAddr)
 
@@ -172,6 +183,8 @@ func main() {
 	}
 
 	http.HandleFunc("/sfu/get", handler.handle)
+	http.HandleFunc("/healthz", handler.healthcheck)
+
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 


### PR DESCRIPTION
When deploying this to k8s in some environments we require all containers to have liveness / readiness probes.

This change deploys a very simple health check endpoint on `/healthz` that responds with a 200 when a GET request is made. That's all we really need for now, frankly.